### PR TITLE
Bugfix: Escape de URL de referência.

### DIFF
--- a/lib/harvard.sty
+++ b/lib/harvard.sty
@@ -5,9 +5,9 @@
 \ProvidesPackage{harvard}
 \RequirePackage{ifthen}
 \IfFileExists{html.sty}{\RequirePackage{html}
-\newcommand{\harvardurl}[1]{\htmladdnormallink*{\textbf{URL:} \textit{##1}}{##1}}
+\newcommand{\harvardurl}[1]{\htmladdnormallink*{\textbf{URL:} \url{##1}}{##1}}
 }{
-\newcommand{\harvardurl}[1]{\textbf{URL:} \textit{##1}}
+\newcommand{\harvardurl}[1]{\textbf{URL:} \url{##1}}
 }
 \DeclareOption{full}{\citationmode{full}}
 \DeclareOption{abbr}{\citationmode{abbr}}


### PR DESCRIPTION
Aplica escape para URL das referências. Toda URL que possui caractere que necessita de escape (_, &, etc) quebrava a compilação.